### PR TITLE
more missing t: and a fix for grlbwt file reading

### DIFF
--- a/prokrustean.cdbg.cpp
+++ b/prokrustean.cdbg.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv){
 
 	if(argc < 2) help();
 	int opt;
-	while ((opt = getopt(argc, argv, "hp:k:s:o:t")) != -1){
+	while ((opt = getopt(argc, argv, "hp:k:s:o:t:")) != -1){
 		switch (opt){
 			case 'h':
 				help();

--- a/prokrustean.kmer.count.cpp
+++ b/prokrustean.kmer.count.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv){
 
 	if(argc < 2) help();
 	int opt;
-	while ((opt = getopt(argc, argv, "hi:l:r:o:p:t")) != -1){
+	while ((opt = getopt(argc, argv, "hi:l:r:o:p:t:")) != -1){
 		switch (opt){
 			case 'h':
 				help();

--- a/scripts/get_bwt_grl.py
+++ b/scripts/get_bwt_grl.py
@@ -4,6 +4,7 @@ import gzip
 import subprocess
 from Bio import SeqIO
 import gzip
+
 ##################################################
 # sdsl-lite installation - grlbwt uses it
 ##################################################
@@ -47,58 +48,66 @@ def is_program_installed(program):
 
 
 def process_sequence_file(file_path, output_file_path, file_format):
-        concatenated_sequence = ""
-        open_func = gzip.open if file_path.endswith('.gz') else open
-        file_format = FORMAT_MAPPING.get(file_format.lower())
-        with open_func(file_path, "rt") as file:
-            for record in SeqIO.parse(file, file_format):
-                sequence = str(record.seq).upper()  # Convert sequence to uppercase
-                concatenated_sequence += sequence + '$'
+    concatenated_sequence = ""
+    open_func = gzip.open if file_path.endswith('.gz') else open
+    file_format = FORMAT_MAPPING.get(file_format.lower())
+    with open_func(file_path, "rt") as file:
+        for record in SeqIO.parse(file, file_format):
+            sequence = str(record.seq).upper()  # Convert sequence to uppercase
+            concatenated_sequence += sequence + '$'
 
-        with open(output_file_path, 'w') as file:
-            file.write(concatenated_sequence)
+    with open(output_file_path, 'w') as file:
+        file.write(concatenated_sequence)
 
 
 def run_grlbwt(file_path, out_file_path, out_txt_file_path, num_threads):
-        os.system(f'grlbwt-cli {file_path} -o {out_file_path} -T . -t {num_threads}')
-        os.system(f'grl2plain {out_file_path}.rl_bwt {out_txt_file_path}')
+    # change the -T value to be the basename of the out_file_path
+    print(f'grlbwt-cli {file_path} -o {out_file_path} -T {os.path.dirname(out_file_path)} -t {num_threads}')
+    os.system(f'grlbwt-cli {file_path} -o {out_file_path} -T {os.path.dirname(out_file_path)} -t {num_threads}')
+    #print(f"grl2plain {out_file_path}.rl_bwt {out_txt_file_path}")
+    #os.system(f'grl2plain {out_file_path}.rl_bwt {out_txt_file_path}')
+    # need to remove one of the extensions from the out_file_path.rl_bwt, if it exists
+    # so if the out_file_path is "x_x_x.fastq.gz.txt.rl_bwt", then we want to remove ".txt"
+    print(f"grl2plain {out_file_path.rsplit('.', 1)[0]}.rl_bwt {out_txt_file_path}")
+    os.system(f"grl2plain {out_file_path.rsplit('.', 1)[0]}.rl_bwt {out_txt_file_path}")
 
 
 def main(input, num_threads, save_intermediate):
     # input file fastq name ex. "./downloads/x_x_x.fastq.gz"
     in_path_for_fastq_file = input
-    extension=''
+    extension = ''
     for file_ending in FORMAT_MAPPING:
         if str.endswith(input, file_ending):
             extension = file_ending
             break
     if not extension:
         raise ValueError(f'File must be one of the following formats: {FORMAT_MAPPING.keys()}')
-    
 
     if not is_program_installed('grlbwt-cli'):
         raise EnvironmentError("grlbwt-cli is not installed. Please install it to continue.")
     if not is_program_installed('grl2plain'):
         raise EnvironmentError("grl2plain is not installed. Please install it to continue.")
 
-    # input file becomes concatenated ex. "./downloads/x_x_x.txt"
-    in_path_for_concatenated_string = in_path_for_fastq_file.replace(extension, ".txt")
-    # grlbwt processed. they don't like underscore ex. "./downloads/xxx.txt"
-    out_path_grlbwt_rl_bwt_file = in_path_for_fastq_file.replace(extension, "").replace("_", "")
-    # grlbwt processed to text. ex. "./downloads/x_x_x.bwt"
-    out_txt_path_grlbwt_txt_file = in_path_for_fastq_file.replace(extension, ".bwt")
+    # concatenated input file
+    in_path_for_concatenated_string = in_path_for_fastq_file + ".txt"
+    # grlbwt processed; auto-adds the .rl_bwt extension. I just need to remove the extension from the input file. Note:
+    # there could be many `.` in the file name, so just take the last one.
+    #out_path_grlbwt_rl_bwt_file = in_path_for_fastq_file.rsplit('.', 1)[0]
+    out_path_grlbwt_rl_bwt_file = in_path_for_fastq_file
+    # grlbwt processed to text. ex. ".{file}.bwt"
+    out_txt_path_grlbwt_txt_file = in_path_for_fastq_file + ".bwt"
     print(f'input: {input}')
     print(f'sequences will be concatenated : {in_path_for_concatenated_string}')
     print(f'grlbwt will be processed : {out_path_grlbwt_rl_bwt_file}')
     print(f'grlbwt output will be converted to txt : {out_txt_path_grlbwt_txt_file}')
-    
-    # preprocess 
+
+    # preprocess
     if os.path.isfile(in_path_for_concatenated_string):
         print('already concatenated')
     else:
         process_sequence_file(in_path_for_fastq_file, in_path_for_concatenated_string, extension)
 
-    # grlbwt and conversion to txt 
+    # grlbwt and conversion to txt
     run_grlbwt(in_path_for_concatenated_string, out_path_grlbwt_rl_bwt_file, out_txt_path_grlbwt_txt_file, num_threads)
 
     # Remove intermediate files
@@ -115,7 +124,8 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-i', metavar='path', required=True, help='The path to input FASTQ or FASTQ.gz file')
-    parser.add_argument('-t', metavar='threads', required=False, default=1, help='The number of threads used to run the BWT construction.')
+    parser.add_argument('-t', metavar='threads', required=False, default=1,
+                        help='The number of threads used to run the BWT construction.')
     parser.add_argument('--save_intermediate', action='store_true', help='Save intermediate files')
     args = parser.parse_args()
     save_intermediate = args.save_intermediate


### PR DESCRIPTION
The `t:` is straight forward. As for the grlbwt stuff, I _think_ it should now work regardless of file names and special characters as it works on things with `_`, multiple `.`, etc. etc.